### PR TITLE
SNESControllersUSB: Fix NES Controller detection

### DIFF
--- a/SNESControllersUSB/SNESControllersUSB.ino
+++ b/SNESControllersUSB/SNESControllersUSB.ino
@@ -193,7 +193,7 @@ void detectControllerTypes()
     // Check controller types and set buttonCount to max needed
     for(gp=0; gp<GAMEPAD_COUNT; gp++) 
     {
-      if((buttons[gp][0] & 0xF3A) == 0xF3A) {   // NES
+      if((buttons[gp][0] & 0x3A) == 0x3A) {   // NES
         if(controllerType[gp] != SNES)
           controllerType[gp] = NES;
         if(buttonCountNew < 8)


### PR DESCRIPTION
Tested with a NES-004E & SNSP-005.
The SNESNTTControllersUSB sketch worked fine for me (0x3A) but the SNESControllersUSB didn't (0xF3A).